### PR TITLE
fix: update CRA to 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "aws-amplify": "^4.1.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-scripts": "4.0.3",
+    "react-scripts": "^5.0.1",
     "web-vitals": "^1.0.1"
   },
   "scripts": {


### PR DESCRIPTION
This PR updates CRA to version 5 because Amplify UI has an https://github.com/aws-amplify/amplify-ui/issues/1656#issuecomment-1095389881 with CRA version 4.